### PR TITLE
feat: Introduce Home screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,8 +34,14 @@
         <activity
             android:name=".paywall.PaywallActivity"
             android:theme="@style/Theme.NorwegianTraining" />
+
         <activity
             android:name=".main.MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.NorwegianTraining" />
+
+        <activity
+            android:name=".home.HomeActivity"
             android:exported="true"
             android:theme="@style/Theme.NorwegianTraining">
             <intent-filter>

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/components/SharedComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/components/SharedComposables.kt
@@ -95,12 +95,13 @@ fun ExoplayerExample() {
 
 @Composable
 fun Toolbar(
-    name: String, backDispatcher: OnBackPressedDispatcher? = null
+    name: String,
+    backDispatcher: OnBackPressedDispatcher? = null,
+    modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .padding(vertical = 16.dp)
     ) {
         if (backDispatcher != null) {

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeActivity.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeActivity.kt
@@ -1,0 +1,102 @@
+package com.github.jibbo.norwegiantraining.home
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.github.jibbo.norwegiantraining.R
+import com.github.jibbo.norwegiantraining.components.BaseActivity
+import com.github.jibbo.norwegiantraining.components.Toolbar
+import com.github.jibbo.norwegiantraining.components.localizable
+import com.github.jibbo.norwegiantraining.ui.theme.NorwegianTrainingTheme
+
+class HomeActivity : BaseActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            NorwegianTrainingTheme(darkTheme = true) {
+                Scaffold { _ ->
+                    HomeView()
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun HomeView() {
+        Column(
+            modifier = Modifier
+                .safeDrawingPadding()
+                .padding(horizontal = 16.dp)
+        ) {
+            Header()
+            Streak()
+        }
+    }
+
+    @Composable
+    internal fun Header() {
+//        val state by viewModel.uiStates.collectAsState()
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.safeDrawingPadding()
+        ) {
+            Toolbar(
+                name = R.string.welcome.localizable("TODO"),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = { TODO() }) {
+                Icon(
+                    painter = painterResource(R.drawable.outline_area_chart_24),
+                    contentDescription = ""
+                )
+            }
+            IconButton(onClick = { TODO() }) {
+                Icon(
+                    painter = painterResource(R.drawable.baseline_settings_24),
+                    contentDescription = ""
+                )
+            }
+        }
+    }
+
+    @Composable
+    internal fun Streak() {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Card {
+
+                Text(
+                    text = "Streak",
+                )
+
+            }
+        }
+    }
+
+    @Preview
+    @Composable
+    fun HomeViewPreview() {
+        NorwegianTrainingTheme {
+            Scaffold { _ ->
+                HomeView()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/main/MainActivity.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/main/MainActivity.kt
@@ -13,7 +13,6 @@ import android.util.Log
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.annotation.RequiresPermission
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.flowWithLifecycle
@@ -38,7 +37,6 @@ class MainActivity : BaseActivity() {
 
     private var tts: TextToSpeech? = null
 
-    @RequiresPermission(Manifest.permission.SCHEDULE_EXACT_ALARM)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)


### PR DESCRIPTION
This commit introduces the initial `HomeActivity` which will serve as the main screen of the app.

Key changes:
- Added `HomeActivity.kt` with basic composables for the home screen UI (`HomeView`, `Header`, `Streak`).
- Registered `HomeActivity` in `AndroidManifest.xml` and set it as the launcher activity.
- Made `MainActivity` no longer the launcher activity.
- Updated the `Toolbar` composable to accept a `modifier` parameter.
- Removed an unnecessary permission annotation from `MainActivity`.