### PR TITLE
Refactor: Remove DI from PaywallActivity

### DIFF
--- a/app/src/main/java/com/github/jibbo/norwegiantraining/paywall/PaywallActivity.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/paywall/PaywallActivity.kt
@@ -3,10 +3,9 @@ package com.github.jibbo.norwegiantraining.paywall
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Scaffold
 import com.github.jibbo.norwegiantraining.components.BaseActivity
-import com.github.jibbo.norwegiantraining.data.SettingsRepository
+import com.github.jibbo.norwegiantraining.data.SharedPreferencesSettingsRepository
 import com.github.jibbo.norwegiantraining.main.MainActivity
 import com.github.jibbo.norwegiantraining.ui.theme.NorwegianTrainingTheme
 import com.revenuecat.purchases.CustomerInfo
@@ -15,13 +14,9 @@ import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIP
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
-import javax.inject.Inject
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 class PaywallActivity : BaseActivity() {
-
-    @Inject
-    lateinit var settingsRepository: SettingsRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -56,7 +51,7 @@ class PaywallActivity : BaseActivity() {
 
     fun goToMainActivityIfPaid(customerInfo: CustomerInfo) {
         if (customerInfo.entitlements.active.isNotEmpty()) {
-            settingsRepository.onboardingCompleted()
+            SharedPreferencesSettingsRepository(this).onboardingCompleted()
             startActivity(Intent(this@PaywallActivity, MainActivity::class.java))
         }
     }


### PR DESCRIPTION
This commit refactors `PaywallActivity` to remove the dependency on Dagger for injecting `SettingsRepository`.

Instead of using an injected `SettingsRepository` instance, the activity now directly instantiates `SharedPreferencesSettingsRepository` when needed. This simplifies the activity by removing the `@Inject` annotation and the associated field.