### PR TITLE
feat: reduce free trial duration from 14 to 3 days

### DIFF
--- a/app/src/main/java/com/github/jibbo/norwegiantraining/data/SettingsRepository.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/data/SettingsRepository.kt
@@ -105,7 +105,7 @@ class SharedPreferencesSettingsRepository @Inject constructor(
     }
 
     override fun startFreeTrial() {
-        sp.edit { putLong("free_trial_date", System.currentTimeMillis() + 14L * 24 * 60 * 60 * 1000) }
+        sp.edit { putLong("free_trial_date", System.currentTimeMillis() + 3L * 24 * 60 * 60 * 1000) }
     }
 
     override fun setRecommendedWorkoutId(id: Long) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -113,7 +113,7 @@
 
     <!-- Free Trial -->
     <string name="free_trial_title">¡Es un regalo de nuestra parte!</string>
-    <string name="free_trial_subtitle">Disfruta del acceso a la app durante las próximas 14 días. Sin compromiso.</string>
+    <string name="free_trial_subtitle">Disfruta del acceso a la app durante las próximas 3 días. Sin compromiso.</string>
     <string name="free_trial_button">RECLAMA TUS DÍAS GRATIS AHORA</string>
     <string name="share">Compartir</string>
     <string name="subscription_section_title">Suscripción</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -112,8 +112,8 @@
 
     <!-- Prova gratuita -->
     <string name="free_trial_title">Ecco un regalo da parte nostra!</string>
-    <string name="free_trial_subtitle">Accedi all\'app per le prossime 14 ore. Senza impegno.</string>
-    <string name="free_trial_button">RICHIEDI SUBITO 14 GIORNI GRATUITI</string>
+    <string name="free_trial_subtitle">Accedi all\'app per i prossimi 3 giorni. Gratuitamente e senza impegno.</string>
+    <string name="free_trial_button">RICHIEDI SUBITO 3 GIORNI GRATUITI</string>
     <string name="share">Condividi</string>
     <string name="subscription_section_title">Abbonamento</string>
     <string name="subscription_section_status">Stato</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,8 +141,8 @@
 
     <!-- Free Trial -->
     <string name="free_trial_title">Here is a gift from us.</string>
-    <string name="free_trial_subtitle">Enjoy the access to the app for the next 14 days. No strings attached.</string>
-    <string name="free_trial_button">CLAIM 14 FREE DAYS NOW</string>
+    <string name="free_trial_subtitle">Enjoy the access to the app for the next 3 days. No strings attached.</string>
+    <string name="free_trial_button">CLAIM 3 FREE DAYS NOW</string>
     <string name="free_trial">Free Trial</string>
 
     <!-- Onboarding - Hook -->


### PR DESCRIPTION
This commit updates the application's free trial period logic and the corresponding UI strings across multiple locales.

Key changes:
- Updated `SettingsRepository` to set the `free_trial_date` to 3 days from the current time instead of 14.
- Adjusted `free_trial_subtitle` and `free_trial_button` in the default, Spanish (`es`), and Italian (`it`) `strings.xml` files to reflect the new 3-day duration.