### PR TITLE
feat: simplify workout time display and fix home screen padding

### DIFF
--- a/.idea/planningMode.xml
+++ b/.idea/planningMode.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="053b011c-429c-41c6-8169-87ce089ce58d" value="false" />
         <entry key="20260716-210205-624ab40d-04c5-4c42-930d-7e30afab4b33" value="true" />
+        <entry key="25dcc00b-8073-44b6-ae42-da16836f4fc3" value="false" />
         <entry key="73af685c-2745-4048-af85-1d4f94c9c4e9" value="false" />
       </map>
     </option>

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/components/BaseActivity.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/components/BaseActivity.kt
@@ -1,6 +1,7 @@
 package com.github.jibbo.norwegiantraining.components
 
 import android.os.Bundle
+import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
 import com.github.jibbo.norwegiantraining.data.Analytics

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -1,5 +1,6 @@
 package com.github.jibbo.norwegiantraining.home
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,11 +12,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush.Companion.verticalGradient
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -65,21 +66,9 @@ import java.util.Calendar
 
 @Composable
 internal fun HomeView(viewModel: HomeViewModel, innerPadding: PaddingValues) {
-    val state = viewModel.uiStates.collectAsState()
-//    Box(
-//        modifier = Modifier
-//            .fillMaxSize()
-//            .background(color = Black)
-//    ) {
-//        Image(
-//            painter = painterResource(id = R.drawable.runner_illustration),
-//            contentDescription = null,
-//            contentScale = ContentScale.Fit,
-//            modifier = Modifier
-//                .width(800.dp)
-//                .align(Alignment.BottomEnd)
-//        )
-//    }
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -93,24 +82,110 @@ internal fun HomeView(viewModel: HomeViewModel, innerPadding: PaddingValues) {
             )
     ) {
     }
+
+    if (isLandscape) {
+        LandscapeLayout(viewModel, innerPadding)
+    } else {
+        PortraitLayout(viewModel, innerPadding)
+    }
+}
+
+@Composable
+private fun PortraitLayout(
+    viewModel: HomeViewModel,
+    innerPadding: PaddingValues
+) {
     Column(
         modifier = Modifier
             .padding(innerPadding)
             .fillMaxSize()
     ) {
-        if (state.value is UiState.Loading) {
-            CircularProgressIndicator()
-        } else {
+        CircularProgressIndicator()
+        Header(viewModel)
+        StreakWidget(viewModel)
+        Box(
+            modifier = Modifier.safeDrawingPadding(),
+            contentAlignment = Alignment.Center
+        ) {
+            Workouts(viewModel)
+        }
+    }
+}
+
+@Composable
+private fun LandscapeLayout(
+    viewModel: HomeViewModel,
+    innerPadding: PaddingValues
+) {
+    Row(
+        modifier = Modifier
+            .padding(innerPadding)
+            .fillMaxSize(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Left column: Header + Streak + Next Up
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
             Header(viewModel)
             StreakWidget(viewModel)
-            Box(
-                modifier = Modifier.safeDrawingPadding(),
-                contentAlignment = Alignment.Center
-            ) {
-                Workouts(viewModel)
-            }
+            NextUpWorkout(viewModel)
         }
 
+        // Right column: All Workouts (scrollable LazyColumn)
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            AllWorkouts(viewModel)
+        }
+    }
+}
+
+@Composable
+private fun NextUpWorkout(viewModel: HomeViewModel) {
+    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
+    val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.padding(12.dp)
+    ) {
+        Text(
+            text = R.string.home_next_up.localizable(),
+            modifier = Modifier.padding(bottom = 12.dp),
+            style = Typography.titleLarge,
+            fontWeight = FontWeight.Normal
+        )
+        val workout = allWorkouts.firstOrNull() ?: return
+        WorkoutCard(
+            workout,
+            viewModel
+        )
+    }
+}
+
+@Composable
+private fun AllWorkouts(viewModel: HomeViewModel) {
+    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
+    val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
+    val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
+
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        item {
+            Text(
+                text = R.string.home_all_workouts.localizable(),
+                modifier = Modifier.padding(bottom = 12.dp),
+                style = Typography.titleLarge,
+                fontWeight = FontWeight.Normal
+            )
+        }
+        items(otherWorkouts.size, { it }) { index ->
+            WorkoutCard(otherWorkouts[index], viewModel)
+        }
     }
 }
 
@@ -191,14 +266,6 @@ private fun Month(weeklySessions: List<Session?>) {
             }
         }
     }
-//    Row(modifier = Modifier.padding(top = 6.dp)) {
-//        Text(
-//            "A good streak has at least 3 workouts per week",
-//            style = Typography.labelSmall,
-//            color = White,
-//            modifier = Modifier.alpha(0.8f)
-//        )
-//    }
 }
 
 @Composable

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
@@ -93,6 +95,7 @@ internal fun HomeView(viewModel: HomeViewModel, innerPadding: PaddingValues) {
     }
     Column(
         modifier = Modifier
+            .padding(innerPadding)
             .fillMaxSize()
     ) {
         if (state.value is UiState.Loading) {
@@ -295,7 +298,7 @@ private fun WorkoutCard(
             color = White
         )
         Text(
-            text = R.string.workout_time.localizable(workout.totalTime, workout.restTime()),
+            text = R.string.workout_time.localizable(workout.totalTime),
             modifier = Modifier.padding(8.dp),
             style = Typography.bodyMedium,
             color = White

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -16,8 +16,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -46,7 +48,6 @@ import com.github.jibbo.norwegiantraining.data.FakeSettingsRepository
 import com.github.jibbo.norwegiantraining.data.FakeTracker
 import com.github.jibbo.norwegiantraining.data.FakeWorkoutRepo
 import com.github.jibbo.norwegiantraining.data.Session
-import com.github.jibbo.norwegiantraining.data.SessionRepository
 import com.github.jibbo.norwegiantraining.data.Workout
 import com.github.jibbo.norwegiantraining.domain.GetAllWorkouts
 import com.github.jibbo.norwegiantraining.domain.GetRecommendedWorkoutId
@@ -95,19 +96,24 @@ private fun PortraitLayout(
     viewModel: HomeViewModel,
     innerPadding: PaddingValues
 ) {
+    val state = viewModel.uiStates.collectAsState().value
     Column(
         modifier = Modifier
             .padding(innerPadding)
-            .fillMaxSize()
+            .fillMaxSize(),
     ) {
-        CircularProgressIndicator()
-        Header(viewModel)
-        StreakWidget(viewModel)
-        Box(
-            modifier = Modifier.safeDrawingPadding(),
-            contentAlignment = Alignment.Center
-        ) {
-            Workouts(viewModel)
+        when (state) {
+            is UiState.Loading -> CircularProgressIndicator()
+            is UiState.Loaded -> {
+                Header(viewModel)
+                StreakWidget(viewModel)
+                Box(
+                    modifier = Modifier.safeDrawingPadding(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Workouts(viewModel)
+                }
+            }
         }
     }
 }
@@ -121,12 +127,14 @@ private fun LandscapeLayout(
         modifier = Modifier
             .padding(innerPadding)
             .fillMaxSize(),
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         // Left column: Header + Streak + Next Up
         Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Header(viewModel)
             StreakWidget(viewModel)
@@ -144,84 +152,105 @@ private fun LandscapeLayout(
 
 @Composable
 private fun NextUpWorkout(viewModel: HomeViewModel) {
-    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
-    val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
+    when (val state = viewModel.uiStates.collectAsState().value) {
+        is UiState.Loading -> CircularProgressIndicator(modifier = Modifier.padding(12.dp))
+        is UiState.Loaded -> {
+            val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
 
-    Column(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.padding(12.dp)
-    ) {
-        Text(
-            text = R.string.home_next_up.localizable(),
-            modifier = Modifier.padding(bottom = 12.dp),
-            style = Typography.titleLarge,
-            fontWeight = FontWeight.Normal
-        )
-        val workout = allWorkouts.firstOrNull() ?: return
-        WorkoutCard(
-            workout,
-            viewModel
-        )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.padding(12.dp)
+            ) {
+                Text(
+                    text = R.string.home_next_up.localizable(),
+                    modifier = Modifier.padding(bottom = 12.dp),
+                    style = Typography.titleLarge,
+                    fontWeight = FontWeight.Normal
+                )
+                val workout = allWorkouts.firstOrNull() ?: return
+                WorkoutCard(
+                    workout,
+                    viewModel
+                )
+            }
+        }
     }
 }
 
 @Composable
 private fun AllWorkouts(viewModel: HomeViewModel) {
-    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
-    val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
-    val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
-
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.fillMaxSize()
-    ) {
-        item {
-            Text(
-                text = R.string.home_all_workouts.localizable(),
-                modifier = Modifier.padding(bottom = 12.dp),
-                style = Typography.titleLarge,
-                fontWeight = FontWeight.Normal
-            )
+    when (val state = viewModel.uiStates.collectAsState().value) {
+        is UiState.Loading -> {
+            CircularProgressIndicator(modifier = Modifier.padding(12.dp))
         }
-        items(otherWorkouts.size, { it }) { index ->
-            WorkoutCard(otherWorkouts[index], viewModel)
+
+        is UiState.Loaded -> {
+            val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
+            val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
+
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxSize()
+            ) {
+                item {
+                    Text(
+                        text = R.string.home_all_workouts.localizable(),
+                        modifier = Modifier.padding(bottom = 12.dp),
+                        style = Typography.titleLarge,
+                        fontWeight = FontWeight.Normal
+                    )
+                }
+                items(otherWorkouts.size, { it }) { index ->
+                    WorkoutCard(otherWorkouts[index], viewModel)
+                }
+            }
         }
     }
 }
 
 @Composable
 private fun StreakWidget(viewModel: HomeViewModel) {
-    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
-    ElevatedCard(
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = Black
-        ),
-        shape = RoundedCornerShape(12.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(12.dp),
-        onClick = { TODO() }
-    ) {
-        Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.padding(12.dp)
+    when (val state = viewModel.uiStates.collectAsState().value) {
+        is UiState.Loading -> {
+            CircularProgressIndicator(modifier = Modifier.padding(12.dp))
+        }
+
+        is UiState.Loaded -> {
+            ElevatedCard(
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = Color.Black
+                ),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+                onClick = { TODO() }
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(64.dp)
-                        .background(color = Primary, shape = CircleShape),
-                    contentAlignment = Alignment.Center
+                Row(
+                    modifier = Modifier.padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_launcher_foreground),
-                        contentDescription = "",
-                        tint = Black,
-                    )
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.padding(12.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(64.dp)
+                                .background(color = Primary, shape = CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_launcher_foreground),
+                                contentDescription = "",
+                                tint = Black,
+                            )
+                        }
+                    }
+                    Column {
+                        Month(state.weeklySessions)
+                    }
                 }
-            }
-            Column {
-                Month(state.weeklySessions)
             }
         }
     }
@@ -270,73 +299,85 @@ private fun Month(weeklySessions: List<Session?>) {
 
 @Composable
 internal fun Header(viewModel: HomeViewModel) {
-    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .safeDrawingPadding()
-    ) {
-        Toolbar(
-            name = R.string.welcome.localizable(state.username ?: ""),
-            modifier = Modifier.weight(1f),
-        )
-        IconButton(onClick = { viewModel.chartsClicked() }) {
-            Icon(
-                painter = painterResource(R.drawable.outline_area_chart_24),
-                contentDescription = ""
-            )
+    when (val state = viewModel.uiStates.collectAsState().value) {
+        is UiState.Loading -> {
+            CircularProgressIndicator(modifier = Modifier.safeDrawingPadding())
         }
-        IconButton(onClick = { viewModel.settingsClicked() }) {
-            Icon(
-                painter = painterResource(R.drawable.baseline_settings_24),
-                contentDescription = ""
-            )
+
+        is UiState.Loaded -> {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .safeDrawingPadding()
+            ) {
+                Toolbar(
+                    name = R.string.welcome.localizable(state.username ?: ""),
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = { viewModel.chartsClicked() }) {
+                    Icon(
+                        painter = painterResource(R.drawable.outline_area_chart_24),
+                        contentDescription = ""
+                    )
+                }
+                IconButton(onClick = { viewModel.settingsClicked() }) {
+                    Icon(
+                        painter = painterResource(R.drawable.baseline_settings_24),
+                        contentDescription = ""
+                    )
+                }
+            }
         }
     }
 }
 
 @Composable
 internal fun Workouts(viewModel: HomeViewModel) {
-    val state = viewModel.uiStates.collectAsState().value as UiState.Loaded
-    val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
-    val recommendedWorkout = allWorkouts.find { it.id == state.recommendedWorkoutId }
-    val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
-
-    Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.padding(12.dp)
-    ) {
-        Text(
-            text = R.string.home_next_up.localizable(),
-            modifier = Modifier.padding(bottom = 12.dp),
-            style = Typography.titleLarge,
-            fontWeight = FontWeight.Normal
-        )
-        if (recommendedWorkout != null) {
-            WorkoutCard(
-                recommendedWorkout,
-                viewModel
-            )
-        } else if (allWorkouts.isNotEmpty()) {
-            WorkoutCard(
-                allWorkouts[0],
-                viewModel
-            )
+    when (val state = viewModel.uiStates.collectAsState().value) {
+        is UiState.Loading -> {
+            CircularProgressIndicator(modifier = Modifier.padding(12.dp))
         }
-        Text(
-            text = R.string.home_all_workouts.localizable(),
-            modifier = Modifier.padding(bottom = 12.dp),
-            style = Typography.titleLarge,
-            fontWeight = FontWeight.Normal
-        )
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = 150.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            items(otherWorkouts.size, { it }) { index ->
-                WorkoutCard(otherWorkouts[index], viewModel)
+
+        is UiState.Loaded -> {
+            val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
+            val recommendedWorkout = allWorkouts.find { it.id == state.recommendedWorkoutId }
+            val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.padding(12.dp)
+            ) {
+                Text(
+                    text = R.string.home_next_up.localizable(),
+                    style = Typography.titleLarge,
+                    fontWeight = FontWeight.Normal
+                )
+                if (recommendedWorkout != null) {
+                    WorkoutCard(
+                        recommendedWorkout,
+                        viewModel
+                    )
+                } else if (allWorkouts.isNotEmpty()) {
+                    WorkoutCard(
+                        allWorkouts[0],
+                        viewModel
+                    )
+                }
+                Text(
+                    text = R.string.home_all_workouts.localizable(),
+                    style = Typography.titleLarge,
+                    fontWeight = FontWeight.Normal
+                )
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(minSize = 150.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    items(otherWorkouts.size, { it }) { index ->
+                        WorkoutCard(otherWorkouts[index], viewModel)
+                    }
+                }
             }
         }
     }
@@ -350,7 +391,7 @@ private fun WorkoutCard(
     val cardShape = RoundedCornerShape(12.dp)
     ElevatedCard(
         colors = CardDefaults.elevatedCardColors(
-            containerColor = Black
+            containerColor = Color.Black
         ),
         shape = cardShape,
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -90,7 +90,9 @@
     <!-- Home -->
     <string name="onboarding_step_name_placeholder">Su nombre</string>
     <string name="welcome">Hola %1$s</string>
-    <string name="workout_time">%1$sm (%2$sm descanso)</string>
+    <string name="home_next_up">Siguiente</string>
+    <string name="home_all_workouts">Todos los entrenamientos</string>
+    <string name="workout_time">%1$sm</string>
     <string name="workout_category_beginner">Principiante</string>
     <string name="workout_category_intermediate">Intermedio</string>
     <string name="workout_category_expert">Pro</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -89,7 +89,9 @@
     <!-- Home -->
     <string name="onboarding_step_name_placeholder">Il tuo nome</string>
     <string name="welcome">Ciao %1$s</string>
-    <string name="workout_time">%1$sm (%2$sm riposo)</string>
+    <string name="home_next_up">Prossimo</string>
+    <string name="home_all_workouts">Tutti gli allenamenti</string>
+    <string name="workout_time">%1$sm</string>
     <string name="workout_category_beginner">Principiante</string>
     <string name="workout_category_intermediate">Esordiente</string>
     <string name="workout_category_expert">Pro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@
     <string name="welcome">Welcome %1$s</string>
     <string name="home_next_up">Next Up</string>
     <string name="home_all_workouts">All Workouts</string>
-    <string name="workout_time">%1$sm (%2$sm rest)</string>
+    <string name="workout_time">%1$sm</string>
     <string name="workout_split" translatable="false">%1$sx%1$s</string>
     <string name="workout_kCal" translatable="false">~%1$s kCal 🔥</string>
     <string name="workout_category_beginner">Beginner</string>


### PR DESCRIPTION
This commit simplifies the workout duration display and fixes a layout issue where content could be obscured by system bars. It also improves localization for Spanish and Italian.

Key changes:
- Updated `workout_time` string to only display the total duration, removing the explicit rest time suffix.
- Applied `innerPadding` to the main `Column` in `HomeComposables` to respect scaffold constraints.
- Added missing translations for `home_next_up` and `home_all_workouts` in Spanish and Italian locales.
- Updated `HomeComposables` to pass only the required total time parameter to the localized workout time string.