### PR TITLE
fix: add missing format placeholders to de/fr/zh strings (workout_tim…

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -61,7 +61,7 @@
     <string name="credits_section_cta">Credits anzeigen</string>
     <string name="subscription_section_title">Abonnement</string>
     <string name="subscription_section_status">Status</string>
-    <string name="subscription_section_date">Datum</string>
+    <string name="subscription_section_date">Gültig bis: %1$s</string>
     <string name="app_version">Version %1$s</string>
     <string name="subscription_section_never">Nie</string>
     <string name="title_activity_logs">Protokolle</string>
@@ -99,7 +99,7 @@
     <string name="welcome">Willkommen</string>
     <string name="home_next_up">Nächste</string>
     <string name="home_all_workouts">Alle Trainings</string>
-    <string name="workout_time">Dauer</string>
+    <string name="workout_time">⏱️ %1$s Minuten</string>
     <string name="workout_split" translatable="false" />
     <string name="workout_kCal" translatable="false" />
     <string name="workout_category_beginner">Anfänger</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,7 +99,7 @@
     <string name="welcome">Bienvenue</string>
     <string name="home_next_up">Prochain</string>
     <string name="home_all_workouts">Tous les entraînements</string>
-    <string name="workout_time">Durée</string>
+    <string name="workout_time">⏱️ %1$s minutes</string>
     <string name="workout_split" translatable="false" />
     <string name="workout_kCal" translatable="false" />
     <string name="workout_category_beginner">Débutant</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -99,7 +99,7 @@
     <string name="welcome">欢迎</string>
     <string name="home_next_up">下一个</string>
     <string name="home_all_workouts">所有训练</string>
-    <string name="workout_time">时长</string>
+    <string name="workout_time">⏱️ %1$s 分钟</string>
     <string name="workout_split" translatable="false" />
     <string name="workout_kCal" translatable="false" />
     <string name="workout_category_beginner">初学者</string>


### PR DESCRIPTION
…e, subscription_section_date, welcome)