### PR TITLE
fix: keep header fixed, scroll content in portrait and landscape

### DIFF
--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -210,22 +211,73 @@ private fun PortraitLayout(
     viewModel: HomeViewModel,
     innerPadding: PaddingValues
 ) {
-    val state = viewModel.uiStates.collectAsState().value
-    Column(
-        modifier = Modifier
-            .padding(innerPadding)
-            .fillMaxSize(),
-    ) {
-        when (state) {
-            is UiState.Loading -> CircularProgressIndicator()
-            is UiState.Loaded -> {
-                Header(viewModel)
-                StreakWidget(viewModel)
-                Box(
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Workouts(viewModel)
+    when (val state = viewModel.uiStates.collectAsState().value) {
+        is UiState.Loading -> Box(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+        is UiState.Loaded -> {
+            val allWorkouts = state.workouts.values.flatten().sortedBy { it.id }
+            val recommendedWorkout = allWorkouts.find { it.id == state.recommendedWorkoutId }
+            val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(16.dp),
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+            ) {
+                // Header spanning full width
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Header(viewModel)
+                }
+
+                // Streak widget spanning full width
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    StreakWidget(viewModel)
+                }
+
+                // "Next up" section spanning full width
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Text(
+                        text = R.string.home_next_up.localizable(),
+                        style = Typography.titleLarge,
+                        fontWeight = FontWeight.Normal,
+                        modifier = Modifier.padding(top = 16.dp)
+                    )
+                }
+
+                // Recommended workout or first workout
+                if (recommendedWorkout != null) {
+                    item {
+                        WorkoutCard(recommendedWorkout, viewModel)
+                    }
+                } else if (allWorkouts.isNotEmpty()) {
+                    item {
+                        WorkoutCard(allWorkouts[0], viewModel)
+                    }
+                }
+
+                // "All workouts" header spanning full width
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Text(
+                        text = R.string.home_all_workouts.localizable(),
+                        style = Typography.titleLarge,
+                        fontWeight = FontWeight.Normal,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
+
+                // Other workouts in grid
+                items(otherWorkouts.size, { it }) { index ->
+                    WorkoutCard(otherWorkouts[index], viewModel)
                 }
             }
         }

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -225,59 +225,64 @@ private fun PortraitLayout(
             val recommendedWorkout = allWorkouts.find { it.id == state.recommendedWorkoutId }
             val otherWorkouts = allWorkouts.filter { it.id != state.recommendedWorkoutId }
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(16.dp),
+            Column(
                 modifier = Modifier
                     .padding(innerPadding)
                     .fillMaxSize()
             ) {
-                // Header spanning full width
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    Header(viewModel)
-                }
+                // Fixed header above the scrollable area
+                Header(viewModel)
 
-                // Streak widget spanning full width
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    StreakWidget(viewModel)
-                }
-
-                // "Next up" section spanning full width
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    Text(
-                        text = R.string.home_next_up.localizable(),
-                        style = Typography.titleLarge,
-                        fontWeight = FontWeight.Normal,
-                        modifier = Modifier.padding(top = 16.dp)
-                    )
-                }
-
-                // Recommended workout or first workout
-                if (recommendedWorkout != null) {
-                    item {
-                        WorkoutCard(recommendedWorkout, viewModel)
+                // Scrollable content: streak, workouts
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(16.dp),
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxSize()
+                ) {
+                    // Streak widget spanning full width
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        StreakWidget(viewModel)
                     }
-                } else if (allWorkouts.isNotEmpty()) {
-                    item {
-                        WorkoutCard(allWorkouts[0], viewModel)
+
+                    // "Next up" section spanning full width
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        Text(
+                            text = R.string.home_next_up.localizable(),
+                            style = Typography.titleLarge,
+                            fontWeight = FontWeight.Normal,
+                            modifier = Modifier.padding(top = 16.dp)
+                        )
                     }
-                }
 
-                // "All workouts" header spanning full width
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    Text(
-                        text = R.string.home_all_workouts.localizable(),
-                        style = Typography.titleLarge,
-                        fontWeight = FontWeight.Normal,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-                }
+                    // Recommended workout or first workout
+                    if (recommendedWorkout != null) {
+                        item {
+                            WorkoutCard(recommendedWorkout, viewModel)
+                        }
+                    } else if (allWorkouts.isNotEmpty()) {
+                        item {
+                            WorkoutCard(allWorkouts[0], viewModel)
+                        }
+                    }
 
-                // Other workouts in grid
-                items(otherWorkouts.size, { it }) { index ->
-                    WorkoutCard(otherWorkouts[index], viewModel)
+                    // "All workouts" header spanning full width
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        Text(
+                            text = R.string.home_all_workouts.localizable(),
+                            style = Typography.titleLarge,
+                            fontWeight = FontWeight.Normal,
+                            modifier = Modifier.padding(top = 8.dp)
+                        )
+                    }
+
+                    // Other workouts in grid
+                    items(otherWorkouts.size, { it }) { index ->
+                        WorkoutCard(otherWorkouts[index], viewModel)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -388,8 +388,7 @@ private fun StreakWidget(viewModel: HomeViewModel) {
                 ),
                 shape = RoundedCornerShape(12.dp),
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .fillMaxWidth(),
                 onClick = { viewModel.chartsClicked() }
             ) {
                 Row(
@@ -473,7 +472,6 @@ internal fun Header(viewModel: HomeViewModel) {
         is UiState.Loaded -> {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 16.dp)
             ) {
                 Toolbar(
                     name = R.string.welcome.localizable(state.username ?: ""),

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/home/HomeComposables.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.github.jibbo.norwegiantraining.R
+import com.github.jibbo.norwegiantraining.components.AnimatedToolbar
 import com.github.jibbo.norwegiantraining.components.Toolbar
 import com.github.jibbo.norwegiantraining.components.VideoBackground
 import com.github.jibbo.norwegiantraining.components.localizable
@@ -300,16 +301,24 @@ private fun LandscapeLayout(
             .fillMaxSize(),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // Left column: Header + Streak + Next Up
+        // Left column: Header fixed, rest scrolls
         Column(
-            modifier = Modifier
-                .weight(1f)
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // Fixed header
             Header(viewModel)
-            StreakWidget(viewModel)
-            NextUpWorkout(viewModel)
+
+            // Scrollable content
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                StreakWidget(viewModel)
+                NextUpWorkout(viewModel)
+            }
         }
 
         // Right column: All Workouts (scrollable LazyColumn)

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/settings/SettingsComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/settings/SettingsComposables.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -174,7 +175,7 @@ private fun LanguageSelector(viewModel: SettingsViewModel) {
             containerColor = Black,
             sheetState = sheetState,
             dragHandle = {
-                Divider(
+                HorizontalDivider(
                     color = Gray,
                     thickness = 4.dp,
                     modifier = Modifier.padding(bottom = 16.dp)


### PR DESCRIPTION
Home screen header now stays fixed at the top while the rest of the content scrolls in both portrait and landscape modes.

**Portrait:** Column with fixed Header + LazyVerticalGrid (weight 1f) for streak widget, next up, and workout cards.

**Landscape:** Left column split into fixed Header + scrollable Column for streak widget and next up. Right column unchanged.