### PR TITLE
feat: add haptic feedback for timer start and pause

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <queries>
         <intent>

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/data/FakeRepos.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/data/FakeRepos.kt
@@ -47,6 +47,12 @@ class FakeSettingsRepository : SettingsRepository {
 
     override fun getAnnounceCountdown(): Boolean = false
 
+    override fun setVibrationEnabled(enabled: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getVibrationEnabled(): Boolean = false
+
     override fun setAnalyticsEnabled(enabled: Boolean) {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/data/SettingsRepository.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/data/SettingsRepository.kt
@@ -27,6 +27,8 @@ interface SettingsRepository {
     fun getAnnouncePhaseDesc(): Boolean
     fun setAnnounceCountdown(enabled: Boolean)
     fun getAnnounceCountdown(): Boolean
+    fun setVibrationEnabled(enabled: Boolean)
+    fun getVibrationEnabled(): Boolean
     fun setAnalyticsEnabled(enabled: Boolean)
     fun getAnalyticsEnabled(): Boolean
     fun setCrashReportingEnabled(enabled: Boolean)
@@ -80,6 +82,12 @@ class SharedPreferencesSettingsRepository @Inject constructor(
     }
 
     override fun getAnnounceCountdown(): Boolean = sp.getBoolean(KEY_ANNOUNCE_COUNTDOWN, true)
+
+    override fun setVibrationEnabled(enabled: Boolean) {
+        sp.edit { putBoolean(KEY_VIBRATION_ENABLED, enabled) }
+    }
+
+    override fun getVibrationEnabled(): Boolean = sp.getBoolean(KEY_VIBRATION_ENABLED, true)
 
     override fun setAnalyticsEnabled(enabled: Boolean) {
         sp.edit { putBoolean(KEY_ANALYTICS_ENABLED, enabled) }
@@ -198,6 +206,7 @@ class SharedPreferencesSettingsRepository @Inject constructor(
         const val KEY_LAST_PROGRESSION_DATE = "last_progression_date"
         const val KEY_LAST_WORKOUT_ID = "last_workout_id"
         const val KEY_APP_LANGUAGE_CODE = "app_language"
+        const val KEY_VIBRATION_ENABLED = "vibration_enabled"
 
         fun isEuUser(context: Context): Boolean {
             val tm = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager?

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/service/WorkoutTimerAndroidService.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/service/WorkoutTimerAndroidService.kt
@@ -11,11 +11,15 @@ import android.content.Intent
 import android.os.Build
 import android.os.CountDownTimer
 import android.os.IBinder
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import android.speech.tts.TextToSpeech
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.github.jibbo.norwegiantraining.R
 import com.github.jibbo.norwegiantraining.alarm.AlarmReceiver
+import com.github.jibbo.norwegiantraining.data.SettingsRepository
 import com.github.jibbo.norwegiantraining.domain.PhaseName
 import com.github.jibbo.norwegiantraining.main.MainActivity
 import com.github.jibbo.norwegiantraining.main.description
@@ -35,6 +39,9 @@ class WorkoutTimerAndroidService : Service(), WorkoutTimerService {
 
     @Inject
     lateinit var stateManager: WorkoutTimerStateManager
+
+    @Inject
+    lateinit var settingsRepository: SettingsRepository
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -127,6 +134,11 @@ class WorkoutTimerAndroidService : Service(), WorkoutTimerService {
     }
 
     override suspend fun startTimer() {
+        startTimerInternal()
+        vibrate()
+    }
+
+    private suspend fun startTimerInternal() {
         Log.d(TAG, "Starting timer")
         stateManager.startTimer()
 
@@ -140,11 +152,30 @@ class WorkoutTimerAndroidService : Service(), WorkoutTimerService {
         announcePhaseStart(state.currentPhase.name)
     }
 
+    private fun vibrate() {
+        if (!settingsRepository.getVibrationEnabled()) return
+        val vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (getSystemService(VIBRATOR_MANAGER_SERVICE) as VibratorManager).defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            getSystemService(VIBRATOR_SERVICE) as Vibrator
+        }
+        if (vibrator.hasVibrator()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator.vibrate(VibrationEffect.createOneShot(40, 55))
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(40)
+            }
+        }
+    }
+
     override suspend fun pauseTimer() {
         Log.d(TAG, "Pausing timer")
         countDownTimer?.cancel()
         cancelAlarm()
         stateManager.pauseTimer()
+        vibrate()
         updateNotification()
     }
 
@@ -163,7 +194,7 @@ class WorkoutTimerAndroidService : Service(), WorkoutTimerService {
             // Update notification to show new phase before starting timer
             updateNotification()
             // Automatically start the timer for the next phase
-            startTimer()
+            startTimerInternal()
         }
     }
 
@@ -182,7 +213,7 @@ class WorkoutTimerAndroidService : Service(), WorkoutTimerService {
             // Update notification to show new phase before starting timer
             updateNotification()
             // Automatically start the timer for the next phase
-            startTimer()
+            startTimerInternal()
         }
     }
 
@@ -222,7 +253,7 @@ class WorkoutTimerAndroidService : Service(), WorkoutTimerService {
             stopSelf()
         } else {
             // Automatically start the timer for the next phase
-            startTimer()
+            startTimerInternal()
         }
     }
 

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/settings/SettingsComposables.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/settings/SettingsComposables.kt
@@ -276,6 +276,19 @@ private fun TTSCard(viewModel: SettingsViewModel) {
                     viewModel.setAnnounceCountdown(it)
                 })
             }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            ) {
+                Text(
+                    text = R.string.vibration.localizable(),
+                    style = Typography.bodyMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                MySwitch(checked = state.value.vibrationEnabled, onCheckedChange = {
+                    viewModel.setVibrationEnabled(it)
+                })
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/settings/SettingsViewModel.kt
@@ -35,6 +35,7 @@ internal class SettingsViewModel @Inject constructor(
             announcePhase = settingsRepository.getAnnouncePhase(),
             announcePhaseDesc = settingsRepository.getAnnouncePhaseDesc(),
             announceCountdown = settingsRepository.getAnnounceCountdown(),
+            vibrationEnabled = settingsRepository.getVibrationEnabled(),
             isCrashReportingEnabled = settingsRepository.getCrashReportingEnabled(),
             isAnalyticsEnabled = settingsRepository.getAnalyticsEnabled(),
             isFreeTrial = settingsRepository.getFreeTrialEndDate()?.after(Date()) == true,
@@ -91,6 +92,11 @@ internal class SettingsViewModel @Inject constructor(
         settingsRepository.setAnnounceCountdown(enabled)
         uiStates.value = uiStates.value.copy(announceCountdown = enabled)
         analytics.logAnnounceCountdownBeforeNextPhase(enabled)
+    }
+
+    fun setVibrationEnabled(enabled: Boolean) {
+        settingsRepository.setVibrationEnabled(enabled)
+        uiStates.value = uiStates.value.copy(vibrationEnabled = enabled)
     }
 
     fun toggleAnalytics(enabled: Boolean) {

--- a/app/src/main/java/com/github/jibbo/norwegiantraining/settings/UiState.kt
+++ b/app/src/main/java/com/github/jibbo/norwegiantraining/settings/UiState.kt
@@ -12,6 +12,7 @@ data class UiState(
     val announcePhase: Boolean,
     val announcePhaseDesc: Boolean,
     val announceCountdown: Boolean,
+    val vibrationEnabled: Boolean,
     val isCrashReportingEnabled: Boolean,
     val isAnalyticsEnabled: Boolean,
     val isFreeTrial: Boolean,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -34,6 +34,7 @@
     <string name="announce_phase">Phasenname</string>
     <string name="announce_phase_description">Phasenbeschreibung</string>
     <string name="announce_countdown">Countdown bis zum Ende der Phase</string>
+    <string name="vibration">Vibration bei Timer-Start/Pause</string>
     <string name="title_privacy_section">Datenschutz</string>
     <string name="enable_analytics">Analytik</string>
     <string name="enable_analytics_description">Hilf, die App zu verbessern, indem du anonyme Daten teilst</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -39,6 +39,7 @@
     <string name="announce_phase">Nombre de la fase</string>
     <string name="announce_phase_description">Descripción de la fase</string>
     <string name="announce_countdown">Cuenta regresiva antes de terminar la fase</string>
+    <string name="vibration">Vibración al iniciar/pausar el temporizador</string>
     <string name="title_privacy_section">Privacidad</string>
     <string name="enable_analytics">Recopilación de datos</string>
     <string name="enable_analytics_description">Nos ayuda a mejorar la app según las funciones y opciones más populares</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -34,6 +34,7 @@
     <string name="announce_phase">Nom de la phase</string>
     <string name="announce_phase_description">Description de la phase</string>
     <string name="announce_countdown">Compte à rebours avant la fin de la phase</string>
+    <string name="vibration">Vibration au démarrage/pause du minuteur</string>
     <string name="title_privacy_section">Confidentialité</string>
     <string name="enable_analytics">Analytiques</string>
     <string name="enable_analytics_description">Aider à améliorer l\'application en partageant des données anonymes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -38,6 +38,7 @@
     <string name="announce_phase">Nome della fase</string>
     <string name="announce_phase_description">Descrizione della fase</string>
     <string name="announce_countdown">Conto alla rovescia prima della fine della fase</string>
+    <string name="vibration">Vibrazione all\'avvio/in pausa del timer</string>
     <string name="title_privacy_section">Privacy</string>
     <string name="enable_analytics">Raccolta Dati</string>
     <string name="enable_analytics_description">Ci permette di migliorare l\'app in base a quali funzionalità e opzioni sono popolari</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -34,6 +34,7 @@
     <string name="announce_phase">阶段名称</string>
     <string name="announce_phase_description">相描述</string>
     <string name="announce_countdown">阶段结束前的倒计时</string>
+    <string name="vibration">计时器开始/暂停时振动</string>
     <string name="title_privacy_section">隐私</string>
     <string name="enable_analytics">分析数据</string>
     <string name="enable_analytics_description">通过分享匿名数据帮助改进应用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="announce_phase">Phase name</string>
     <string name="announce_phase_description">Phase description</string>
     <string name="announce_countdown">Countdown before phase ends</string>
+    <string name="vibration">Vibration on timer start/pause</string>
     <string name="title_privacy_section">Privacy</string>">
     <string name="enable_analytics">Data Collection</string>
     <string name="enable_analytics_description">It lets us improve the app based on which features and options are popular</string>


### PR DESCRIPTION
This commit introduces vibration feedback when starting or pausing the workout timer and adds a corresponding toggle in the application settings.

Key changes:
- **Permission**: Added `android.permission.VIBRATE` to `AndroidManifest.xml`.
- **Settings Persistence**: Updated `SettingsRepository` to include `vibration_enabled` in `SharedPreferences`.
- **UI/UX**:
    - Added a "Vibration" toggle to the Settings screen.
    - Included localized string resources for English, German, Spanish, French, Italian, and Chinese.
- **Service Logic**:
    - Implemented haptic feedback logic in `WorkoutTimerAndroidService` using `Vibrator` and `VibratorManager`.
    - Integrated vibration triggers within `startTimer()` and `pauseTimer()`.
    - Refactored `startTimer` into `startTimerInternal` to ensure haptic feedback is only triggered by manual user actions rather than automatic phase transitions.
- **State Management**: Updated `SettingsViewModel` and `UiState` to handle the new vibration preference.